### PR TITLE
Readme: Fix ListToggle Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3219,7 +3219,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [ycmd_flags_example]: https://raw.githubusercontent.com/ycm-core/ycmd/66030cd94299114ae316796f3cad181cac8a007c/.ycm_extra_conf.py
 [compdb]: https://clang.llvm.org/docs/JSONCompilationDatabase.html
 [subsequence]: https://en.wikipedia.org/wiki/Subsequence
-[listtoggle]: https://github.com/ycm-core/ListToggle
+[listtoggle]: https://github.com/Valloric/ListToggle
 [vim-build]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source
 [tracker]: https://github.com/ycm-core/YouCompleteMe/issues?state=open
 [completer-api]: https://github.com/ycm-core/ycmd/blob/master/ycmd/completers/completer.py


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The ListToggle link assumed that the code was hosted in Valloric's github. The code has moved elsewhere therefor the link has broken.

# Why no test

This change is a documentation change. I've tested the new link works manually.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
